### PR TITLE
refact: Support b4a buffers

### DIFF
--- a/example/hello.js
+++ b/example/hello.js
@@ -1,17 +1,18 @@
 var RAI = require('../')
+var b4a = require('b4a')
 const storage = RAI('dbname')
 var cool = storage('cool.txt')
 
-cool.write(100, Buffer.from('GREETINGS'), function (err) {
+cool.write(100, b4a.from('GREETINGS'), function (err) {
   if (err) return console.error(err)
   cool.read(104, 3, function (err, buf) {
     if (err) return console.error(err)
-    console.log(buf.toString()) // TIN
+    console.log(b4a.toString(buf)) // TIN
   })
 
   cool.read(100, 9, function (err, buf) {
     if (err) return console.error(err)
-    console.log(buf.toString()) // GREETINGS
+    console.log(b4a.toString(buf)) // GREETINGS
   })
 
 })

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var once = require('once')
 var blocks = require('./lib/blocks.js')
 var bufferFrom = require('buffer-from')
 var bufferAlloc = require('buffer-alloc')
+var b4a = require('b4a')
 
 var DELIM = '\0'
 
@@ -121,7 +122,7 @@ Store.prototype._write = function (req) {
         block = bufferFrom(req.data.slice(j, j + len))
       } else {
         block = buffers[i]
-        req.data.copy(block, o.start, j, j + len)
+        b4a.copy(req.data, block, o.start, j, j + len)
       }
       store.put(block, self.name + DELIM + o.block)
       j += len

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "b4a": "^1.6.4",
     "buffer-alloc": "^1.2.0",
-    "buffer-from": "^0.1.1",
     "inherits": "^2.0.4",
     "mutexify": "^1.3.1",
     "next-tick": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "version": "1.3.1",
   "main": "index.js",
   "dependencies": {
-    "random-access-storage": "^1.4.1",
+    "b4a": "^1.6.4",
     "buffer-alloc": "^1.2.0",
     "buffer-from": "^0.1.1",
     "inherits": "^2.0.4",
     "mutexify": "^1.3.1",
     "next-tick": "^1.0.0",
-    "once": "^1.4.0"
+    "once": "^1.4.0",
+    "random-access-storage": "^1.4.1"
   },
   "devDependencies": {
     "browser-run": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "mutexify": "^1.3.1",
     "next-tick": "^1.0.0",
     "once": "^1.4.0",
-    "random-access-storage": "^1.4.1"
+    "random-access-storage": "^3.0.0"
   },
   "devDependencies": {
     "browser-run": "^8.0.0",
     "browserify": "^16.5.2",
-    "random-access-memory": "^3.1.1",
+    "random-access-memory": "^6.2.0",
     "randombytes": "^2.1.0",
     "tape": "^5.0.1"
   },

--- a/test/big.js
+++ b/test/big.js
@@ -1,20 +1,21 @@
 var test = require('tape')
 var random = require('../')('testing-' + Math.random(), { size: 1024 })
+var b4a = require('b4a')
 
 test('big', function (t) {
   t.plan(6)
   var cool = random('cool.txt')
-  cool.write(32, Buffer.from('GREETINGS'), function (err) {
+  cool.write(32, b4a.from('GREETINGS'), function (err) {
     t.ifError(err)
-    cool.write(32 + 3, Buffer.from('AT SCOTT'), function (err) {
+    cool.write(32 + 3, b4a.from('AT SCOTT'), function (err) {
       t.ifError(err)
       cool.read(32, 9, function (err, buf) {
         t.ifError(err)
-        t.equal(buf.toString(), 'GREAT SCO')
+        t.equal(b4a.toString(buf), 'GREAT SCO')
       })
       cool.read(32 + 6, 5, function (err, buf) {
         t.ifError(err)
-        t.equal(buf.toString(), 'SCOTT')
+        t.equal(b4a.toString(buf), 'SCOTT')
       })
     })
   })

--- a/test/multifile.js
+++ b/test/multifile.js
@@ -1,35 +1,35 @@
 var test = require('tape')
 var random = require('../')('testing-' + Math.random(), { size: 5 })
-var bfrom = require('buffer-from')
+var b4a = require('b4a')
 
 test('multiple files cool and good', function (t) {
   t.plan(14)
   var cool = random('cool.txt')
   var and = random('and.txt')
   var good = random('good.txt')
-  cool.write(100, bfrom('GREETINGS'), function (err) {
+  cool.write(100, b4a.from('GREETINGS'), function (err) {
     t.ifError(err)
     cool.read(100, 9, function (err, buf) {
       t.ifError(err)
-      t.equal(buf.toString(), 'GREETINGS')
+      t.equal(b4a.toString(buf), 'GREETINGS')
     })
     cool.read(104, 3, function (err, buf) {
       t.ifError(err)
-      t.equal(buf.toString(), 'TIN')
+      t.equal(b4a.toString(buf), 'TIN')
     })
-    and.write(106, bfrom('ORANG'), function (err) {
+    and.write(106, b4a.from('ORANG'), function (err) {
       t.ifError(err)
       and.read(107, 3, function (err, buf) {
         t.ifError(err)
-        t.equal(buf.toString(), 'RAN')
-        good.write(90, bfrom('DO YOU EVER JUST... TEAPOT'), function (err) {
+        t.equal(b4a.toString(buf), 'RAN')
+        good.write(90, b4a.from('DO YOU EVER JUST... TEAPOT'), function (err) {
           t.ifError(err)
           good.read(110, 6, function (err, buf) {
             t.ifError(err)
-            t.equal(buf.toString(), 'TEAPOT')
+            t.equal(b4a.toString(buf), 'TEAPOT')
             good.read(86, 10, function (err, buf) {
               t.ifError(err)
-              t.equal(buf.toString(), '\0\0\0\0DO YOU')
+              t.equal(b4a.toString(buf), '\0\0\0\0DO YOU')
               good.read(110, 10, function (err, buf) {
                 t.ok(err, 'should error when reading past end of file')
               })

--- a/test/random.js
+++ b/test/random.js
@@ -3,6 +3,7 @@ var rai = require('../')('testing-' + Math.random(), { size: 256 })
 var ram = require('random-access-memory')
 var randombytes = require('randombytes')
 var balloc = require('buffer-alloc')
+var b4a = require('b4a')
 
 test('random', function (t) {
   var nwrites = 500
@@ -61,7 +62,7 @@ test('random', function (t) {
         t.ok((data.ierr && data.merr),
           'read: offset=' + offset + ', length=' + len)
       } else {
-        t.ok((data.istore).equals(data.mstore),
+        t.ok(b4a.equals(data.istore, data.mstore),
           'read: offset=' + offset + ', length=' + len)
       }
       read(i + 1)

--- a/test/random.js
+++ b/test/random.js
@@ -1,6 +1,6 @@
 var test = require('tape')
 var rai = require('../')('testing-' + Math.random(), { size: 256 })
-var ram = require('random-access-memory')
+var Ram = require('random-access-memory')
 var randombytes = require('randombytes')
 var balloc = require('buffer-alloc')
 var b4a = require('b4a')
@@ -10,7 +10,7 @@ test('random', function (t) {
   var nreads = 500
   t.plan(2 + nwrites * 2 + nreads)
   var istore = rai('cool.txt')
-  var mstore = ram('cool.txt')
+  var mstore = new Ram('cool.txt')
 
   ;(function () {
     var zeros = balloc(5000 + 1000)

--- a/test/reopen.js
+++ b/test/reopen.js
@@ -1,6 +1,6 @@
 var test = require('tape')
 var rai = require('../')('testing-' + Math.random(), { size: 256 })
-var ram = require('random-access-memory')
+var Ram = require('random-access-memory')
 var randombytes = require('randombytes')
 var balloc = require('buffer-alloc')
 
@@ -13,7 +13,7 @@ test('reopen', function (t) {
   var store = rai('cool.txt')
   function istore () { if (Math.random() > 0.75) store = rai('cool.txt'); return store }
 
-  var mstore = ram('cool.txt')
+  var mstore = new Ram('cool.txt')
 
   ;(function () {
     var zeros = balloc(500 + 100)

--- a/test/simple.js
+++ b/test/simple.js
@@ -1,19 +1,20 @@
 var test = require('tape')
 var random = require('../')('testing-' + Math.random(), { size: 5 })
+var b4a = require('b4a')
 
 test('simple', function (t) {
   t.plan(6)
   var cool = random('cool.txt', { size: 5 })
   t.equal(cool.name, 'cool.txt')
-  cool.write(100, Buffer.from('GREETINGS'), function (err) {
+  cool.write(100, b4a.from('GREETINGS'), function (err) {
     t.ifError(err)
     cool.read(100, 9, function (err, buf) {
       t.ifError(err)
-      t.equal(buf.toString(), 'GREETINGS')
+      t.equal(b4a.toString(buf), 'GREETINGS')
     })
     cool.read(104, 3, function (err, buf) {
       t.ifError(err)
-      t.equal(buf.toString(), 'TIN')
+      t.equal(b4a.toString(buf), 'TIN')
     })
   })
 })


### PR DESCRIPTION
Only `b4a.copy()` was needed to support the 'Buffer for Arrays' used in hypercore.